### PR TITLE
Adds support for the let macro.

### DIFF
--- a/include/macros.sibilant
+++ b/include/macros.sibilant
@@ -352,3 +352,10 @@
                                      (indent (macros.progn val))
                                      "}")))))
           "})()"))
+
+(defmacro let (args &optional body)
+  (concat "let (" (bulk-map args
+    (lambda (h k v)
+      (concat (translate k) " = " (translate v))))
+    (if (undefined? body) ");"
+                (concat ") {" (indent (translate body)) "}"))))


### PR DESCRIPTION
Let translates to the JavaScript let. Examples:

(let { a b })

Translates to:

let (a = b);

(let { a b }
  (return (concat a b)))

Translates to:

let (a = b) {
  return a + b;
}
