### PR TITLE
Added a macro for slice.

### DIFF
--- a/include/macros.sibilant
+++ b/include/macros.sibilant
@@ -362,3 +362,8 @@
 
 (defmacro instance-of? (item type)
   (concat "(" (translate item) " instanceof " (translate type) ")"))
+
+(defmacro slice (list &optional begin &optional end)
+  (concat "Array.prototype.slice.call(" (translate list)
+          ", " (or (translate begin) 0) (if (defined? end) (concat ", "
+          (translate end) ")") ")")))

--- a/test/slice.sibilant
+++ b/test/slice.sibilant
@@ -1,0 +1,3 @@
+(defvar sliced (slice '(1 2 3 4)))
+
+(defvar other (slice '(1 2 3 4) 0 2))


### PR DESCRIPTION
Array.prototype.slice is used often in Sibilant (and JavaScript) so it
makes sense that it has its own macro rather than rewriting the same code
many times.
