### PR TITLE
use this instead of window and check for jquery

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -588,7 +588,7 @@
   (sibilant)["translateAll"] = translateAll;
   ;
   return (function() {
-    if ((typeof $ !== "undefined")) {
+    if ((typeof $ !== 'undefined')) {
       return $((function() {
         var sibilant = root.sibilant,
             scripts = [  ];

--- a/src/browser.sibilant
+++ b/src/browser.sibilant
@@ -7,7 +7,7 @@
   (set root 'sibilant sibilant)
   (include "../include/functional")
   (include "../src/core")
-  (when (!= (typeof $) 'undefined)
+  (when (defined? $)
     ($ (#>
         (var sibilant root.sibilant
              scripts [])


### PR DESCRIPTION
Hi,

I'm not used to lisp, but liked the idea and would like to use it in my rails project (even though I know it actually makes no sense...)
So I write a really small gem to enable it within Rails asset pipeline (https://github.com/tadeuzagallo/sibilant-rails), hope you don't mind...
But while developing, I needed to compile the browser version with ExecJS, and the browser version was incompatible because of the use of `window` and the hard dependency on `jQuery`.
I changed the `window` for `this`, and made the `jQuery` part of the script optional.
I thought it would make no harm to the master branch, if you would like to merge.

Congrats for the nice project.
