### PR TITLE
Apparently, we need cardinal

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "stool": ">=0.0.7",
     "diff": ">=2.2.1",
     "strip-ansi": ">=3.0.0",
-    "colors": ">=1.1.2",
-    "cardinal": ">=0.6.0"
+    "colors": ">=1.1.2"
   },
   "dependencies": {
     "source-map": ">=0.5.3",
-    "source-map-support": ">=0.3.3"
+    "source-map-support": ">=0.3.3",
+    "cardinal": ">=0.6.0"
   },
   "scripts": { "test": "bin/sibilant -x stool.sibilant -- test" }
 }


### PR DESCRIPTION

So, while using sibilant, i found that we in fact need cardinal to use it.
(I get "Error: cannot find module cardinal" every time i run the binary)
This is a quick fix and i dindn't look much into it, but if its needed for running sibilant it should be in dependencies, right?