### PR TITLE
Fix broken compilation when using cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ tmp/*
 node_modules
 .sass-cache
 .#*
+lib/*
+!lib/browser.js
+!lib/cli.js
+!lib/options.js
+!lib/repl.js
+!lib/sibilant.js

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 
 ## Installation
 
+Use version 12.10.0 of node for transpiling Sibilant itself.
+
 For local dev:
 
     $ git clone git://github.com/jbr/sibilant.git

--- a/README.md
+++ b/README.md
@@ -34,13 +34,21 @@
 
 ## Installation
 
-First, install [node.js](http://nodejs.org) [
-[github](http://github.com/ry/node) ] and [npm](http://npmjs.org) [
-[github](http://github.com/isaacs/npm) ].  Then, it's as simple as:
+For local dev:
 
-    $ npm install sibilant -g
-    $ sibilant --help
-    
+    $ git clone git://github.com/jbr/sibilant.git
+    $ npm link .
+    $ sibilant src/*.sibilant -o lib
+    $ sibilant -x test/test.sibilant # you're now running a sibilant you just compiled.
+
+To have sibilant recompile on any change to its source:
+
+    $ npx nodemon -e sibilant -w src -x sibilant src/*.sibilant -o lib
+
+For use in our projects:
+
+    $ npm i --save GowerStreet/sibilant # pulls from github, or local if you did npm link
+
 ## Hello world in the REPL
 
     $ sibilant

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1361,10 +1361,10 @@ this.sibilant = (function() {
   sibilant.macros.namespaces.core.ternary = (function ternary$(cond, ifTrue, ifFalse) {
     /* ternary src/macros/flow-control.sibilant:9:0 */
   
-    return [ "(", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse) ];
+    return [ "(function() {", indent([ "return (", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse), ";" ]), "}).call(this)" ];
   });
   sibilant.macros.namespaces.core.when = (function when$(condition, body) {
-    /* when src/macros/flow-control.sibilant:21:0 */
+    /* when src/macros/flow-control.sibilant:26:0 */
   
     var body = Array.prototype.slice.call(arguments, 1);
   
@@ -1372,13 +1372,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 24,
+      line: 29,
       col: 18,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "do",
         type: "literal",
-        line: 24,
+        line: 29,
         col: 19,
         contents: [],
         specials: 0,
@@ -1392,7 +1392,7 @@ this.sibilant = (function() {
     }), "}");
   });
   sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
-    /* unless src/macros/flow-control.sibilant:33:0 */
+    /* unless src/macros/flow-control.sibilant:38:0 */
   
     var body = Array.prototype.slice.call(arguments, 1);
   
@@ -1400,13 +1400,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 35,
+      line: 40,
       col: 25,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "not",
         type: "literal",
-        line: 35,
+        line: 40,
         col: 26,
         contents: [],
         specials: 0,
@@ -1421,13 +1421,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 36,
+      line: 41,
       col: 33,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "do",
         type: "literal",
-        line: 36,
+        line: 41,
         col: 34,
         contents: [],
         specials: 0,
@@ -1441,12 +1441,12 @@ this.sibilant = (function() {
     }), "}" ]), "}).call(this)" ];
   });
   sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranches) {
-    /* if src/macros/flow-control.sibilant:58:0 */
+    /* if src/macros/flow-control.sibilant:63:0 */
   
     var alternatingConditionsAndBranches = Array.prototype.slice.call(arguments, 0);
   
     return [ "(function() {", indent(interleave(" else ", bulkMap(alternatingConditionsAndBranches, (function(cond, val) {
-      /* src/macros/flow-control.sibilant:63:25 */
+      /* src/macros/flow-control.sibilant:68:25 */
     
       return (function() {
         if (typeof val !== "undefined") {
@@ -1454,13 +1454,13 @@ this.sibilant = (function() {
             file: "src/macros/flow-control.sibilant",
             token: "(",
             type: "expression",
-            line: 66,
+            line: 71,
             col: 44,
             contents: [ {
               file: "src/macros/flow-control.sibilant",
               token: "do",
               type: "literal",
-              line: 66,
+              line: 71,
               col: 45,
               contents: [],
               specials: 0,
@@ -1477,13 +1477,13 @@ this.sibilant = (function() {
             file: "src/macros/flow-control.sibilant",
             token: "(",
             type: "expression",
-            line: 68,
+            line: 73,
             col: 47,
             contents: [ {
               file: "src/macros/flow-control.sibilant",
               token: "do",
               type: "literal",
-              line: 68,
+              line: 73,
               col: 48,
               contents: [],
               specials: 0,

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -28,14 +28,14 @@ this.sibilant = (function() {
         groupSize = fn.length,
         retArr = [];
     (function() {
-      var while$5 = undefined;
+      var while$1 = undefined;
       while (index < arr.length) {
-        while$5 = (function() {
+        while$1 = (function() {
           retArr.push(fn.apply(this, arr.slice(index, (index + groupSize))));
           return index += groupSize;
         }).call(this);
       };
-      return while$5;
+      return while$1;
     }).call(this);
     return retArr;
   });
@@ -561,14 +561,14 @@ this.sibilant = (function() {
         groupSize = fn.length,
         retArr = [];
     (function() {
-      var while$6 = undefined;
+      var while$2 = undefined;
       while (index < arr.length) {
-        while$6 = (function() {
+        while$2 = (function() {
           retArr.push(fn.apply(this, arr.slice(index, (index + groupSize))));
           return index += groupSize;
         }).call(this);
       };
-      return while$6;
+      return while$2;
     }).call(this);
     return retArr;
   });
@@ -838,9 +838,9 @@ this.sibilant = (function() {
         regexName = null,
         remainingInput = string;
     (function() {
-      var while$7 = undefined;
+      var while$3 = undefined;
       while (match) {
-        while$7 = (function() {
+        while$3 = (function() {
           detect(orderedRegexes, (function(r) {
             /* src/parser.sibilant:59:20 */
           
@@ -884,7 +884,7 @@ this.sibilant = (function() {
           }).call(this);
         }).call(this);
       };
-      return while$7;
+      return while$3;
     }).call(this);
     return context.stack;
   });
@@ -1544,7 +1544,7 @@ this.sibilant = (function() {
         return error(("odd number of key-value pairs in hash: " + inspect(pairs)));
       }
     }).call(this);
-    var pairs_reduce$2 = pairs.reduce((function(o, item, i) {
+    var pairs_reduce$1 = pairs.reduce((function(o, item, i) {
       /* src/macros/hash.sibilant:32:26 */
     
       return (function() {
@@ -1560,9 +1560,9 @@ this.sibilant = (function() {
       dynamicKeys: [],
       staticKeys: []
     }),
-        dynamicKeys = pairs_reduce$2.dynamicKeys,
-        staticKeys = pairs_reduce$2.staticKeys,
-        pairs_reduce$2 = undefined;
+        dynamicKeys = pairs_reduce$1.dynamicKeys,
+        staticKeys = pairs_reduce$1.staticKeys,
+        pairs_reduce$1 = undefined;
     var quoteKeys = sibilant.quoteHashKeys,
         pairStrings = bulkMap(staticKeys, (function(key, value) {
       /* src/macros/hash.sibilant:43:47 */
@@ -4334,14 +4334,14 @@ this.sibilant = (function() {
     var body = Array.prototype.slice.call(arguments, 2);
   
     var state = sibilant.state,
-        $2 = map([ k, v ], (function() {
+        $1 = map([ k, v ], (function() {
       /* src/macros/misc.sibilant:71:41 */
     
       return outputFormatter(transpile(arguments[0]));
     })),
-        key = $2[0],
-        value = $2[1],
-        $2 = undefined,
+        key = $1[0],
+        value = $1[1],
+        $1 = undefined,
         before = state[key];
     state[key] = value;
     var returnValue = interleave("\n", map(body, transpile));
@@ -7456,16 +7456,16 @@ this.sibilant = (function() {
     /* transpile.hat src/transpiler.sibilant:55:0 */
   
     var token = node.contents[0].token,
-        if$2 = (function() {
+        if$1 = (function() {
       if (token.match((new RegExp("\/", undefined)))) {
         return token.split("/");
       } else {
         return [ sibilant.macros.searchPath[0], token ];
       }
     }).call(this),
-        namespace = if$2[0],
-        macro = if$2[1],
-        if$2 = undefined;
+        namespace = if$1[0],
+        macro = if$1[1],
+        if$1 = undefined;
     return sibilant.macros.namespaces.core.get.call(node, "sibilant.macros.namespaces", sibilant.macros.namespaces.core.quote(transpile.literal({ token: namespace })), sibilant.macros.namespaces.core.quote(transpile.literal({ token: macro })));
   });
   transpile.tick = (function transpile$tick$(node) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -160,11 +160,11 @@ process.ARGV = args;
   (function() {
     if (outputDir) {
       var outputPath = (path.join(outputDir, inputBasename) + outputExtname);
-      fs.writeFile(outputPath, result.js);
+      fs.writeFileSync(outputPath, result.js);
       return (function() {
         if (mapDir) {
           var mapPath = (path.join(mapDir, inputBasename) + ".map");
-          return fs.writeFile(mapPath, result.map.toString());
+          return fs.writeFileSync(mapPath, result.map.toString());
         }
       }).call(this);
     } else if (cliOptions.execute) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -243,7 +243,9 @@ var mergeWith = (function mergeWith$(into, from) {
 var extractOptions = (function extractOptions$(config, args) {
   /* extract-options src/options.sibilant:3:0 */
 
-  args = (typeof args !== "undefined") ? args : process.argv.slice(2);
+  args = (function() {
+    return (typeof args !== "undefined") ? args : process.argv.slice(2);
+  }).call(this);
   var defaultLabel = "unlabeled",
       currentLabel = defaultLabel,
       afterBreak = false,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -50,14 +50,14 @@ var displayPrompt = (function displayPrompt$() {
       closed = cmdBuffer.split((new RegExp("[\\}\\]\\)]", "g"))).length,
       indentation = "";
   (function() {
-    var while$3 = undefined;
+    var while$6 = undefined;
     while (open > closed) {
-      while$3 = (function() {
+      while$6 = (function() {
         indentation = ("  " + indentation);
         return ((open)--);
       }).call(this);
     };
-    return while$3;
+    return while$6;
   }).call(this);
   readline.setPrompt((function() {
     if (0 === cmdBuffer.length) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -92,7 +92,7 @@ var handleLine = (function handleLine$(cmd) {
       }).call(this);
       var result = vm.runInContext(safeJs, context, "sibilant-repl");
       readline.history[0] = cmdBuffer;
-      fs.write(fd, ("" + cmdBuffer + "\n\n"));
+      fs.writeSync(fd, ("" + cmdBuffer + "\n\n"));
       (function() {
         if (typeof result !== "undefined") {
           return output.write(("result: " + util.inspect(result, { colors: true }) + "\n"));
@@ -107,7 +107,7 @@ var handleLine = (function handleLine$(cmd) {
           return readline.history.shift();
         } else {
           readline.history[0] = cmdBuffer;
-          fs.write(fd, ("" + cmdBuffer + "\n\n"));
+          fs.writeSync(fd, ("" + cmdBuffer + "\n\n"));
           output.write((e.stack + "\n"));
           return cmdBuffer = "";
         }

--- a/lib/sibilant.js
+++ b/lib/sibilant.js
@@ -69,19 +69,19 @@ sibilant.entry = (function sibilant$entry$(source, options) {
   quoteKeys = (typeof quoteKeys !== "undefined") ? quoteKeys : json;
   (function() {
     if (((typeof file !== "undefined" && file !== null) && !((typeof source !== "undefined" && source !== null)))) {
-      var relativeDirAndF$1 = relativeDirAndFile(file),
-          relativeDir = relativeDirAndF$1[0],
-          relativeFile = relativeDirAndF$1[1],
-          relativeDirAndF$1 = undefined;
+      var relativeDirAndF$4 = relativeDirAndFile(file),
+          relativeDir = relativeDirAndF$4[0],
+          relativeFile = relativeDirAndF$4[1],
+          relativeDirAndF$4 = undefined;
       return source = (sibilant.sourceCache[relativeFile] || sibilant.stripShebang(fs.readFileSync(file, "utf8")));
     }
   }).call(this);
   (function() {
     if (file) {
-      var relativeDirAndF$2 = relativeDirAndFile(file),
-          relativeDir = relativeDirAndF$2[0],
-          relativeFile = relativeDirAndF$2[1],
-          relativeDirAndF$2 = undefined;
+      var relativeDirAndF$5 = relativeDirAndFile(file),
+          relativeDir = relativeDirAndF$5[0],
+          relativeFile = relativeDirAndF$5[1],
+          relativeDirAndF$5 = undefined;
       return sibilant.sourceCache[relativeFile] = source;
     }
   }).call(this);
@@ -124,10 +124,10 @@ sibilant.transpileFile = (function sibilant$transpileFile$(fileName) {
     /* src/node.sibilant:77:16 */
   
     var source = sibilant.stripShebang(fs.readFileSync(fileName, "utf8")),
-        relativeDirAndF$3 = relativeDirAndFile(file),
-        relativeDir = relativeDirAndF$3[0],
-        relativeFile = relativeDirAndF$3[1],
-        relativeDirAndF$3 = undefined;
+        relativeDirAndF$6 = relativeDirAndFile(file),
+        relativeDir = relativeDirAndF$6[0],
+        relativeFile = relativeDirAndF$6[1],
+        relativeDirAndF$6 = undefined;
     sibilant.sourceCache[relativeFile] = source;
     return transpile(restructure(parse(source)));
   }));
@@ -545,14 +545,14 @@ var bulkMap = (function bulkMap$(arr, fn) {
       groupSize = fn.length,
       retArr = [];
   (function() {
-    var while$1 = undefined;
+    var while$7 = undefined;
     while (index < arr.length) {
-      while$1 = (function() {
+      while$7 = (function() {
         retArr.push(fn.apply(this, arr.slice(index, (index + groupSize))));
         return index += groupSize;
       }).call(this);
     };
-    return while$1;
+    return while$7;
   }).call(this);
   return retArr;
 });
@@ -822,9 +822,9 @@ parser.parse = (function parser$parse$(string, context) {
       regexName = null,
       remainingInput = string;
   (function() {
-    var while$2 = undefined;
+    var while$8 = undefined;
     while (match) {
-      while$2 = (function() {
+      while$8 = (function() {
         detect(orderedRegexes, (function(r) {
           /* src/parser.sibilant:59:20 */
         
@@ -868,7 +868,7 @@ parser.parse = (function parser$parse$(string, context) {
         }).call(this);
       }).call(this);
     };
-    return while$2;
+    return while$8;
   }).call(this);
   return context.stack;
 });
@@ -1528,7 +1528,7 @@ sibilant.macros.namespaces.core.hash = (function hash$(pairs) {
       return error(("odd number of key-value pairs in hash: " + inspect(pairs)));
     }
   }).call(this);
-  var pairs_reduce$1 = pairs.reduce((function(o, item, i) {
+  var pairs_reduce$4 = pairs.reduce((function(o, item, i) {
     /* src/macros/hash.sibilant:32:26 */
   
     return (function() {
@@ -1544,9 +1544,9 @@ sibilant.macros.namespaces.core.hash = (function hash$(pairs) {
     dynamicKeys: [],
     staticKeys: []
   }),
-      dynamicKeys = pairs_reduce$1.dynamicKeys,
-      staticKeys = pairs_reduce$1.staticKeys,
-      pairs_reduce$1 = undefined;
+      dynamicKeys = pairs_reduce$4.dynamicKeys,
+      staticKeys = pairs_reduce$4.staticKeys,
+      pairs_reduce$4 = undefined;
   var quoteKeys = sibilant.quoteHashKeys,
       pairStrings = bulkMap(staticKeys, (function(key, value) {
     /* src/macros/hash.sibilant:43:47 */
@@ -4318,14 +4318,14 @@ sibilant.macros.namespaces.core.withState = (function withState$(k, v, body) {
   var body = Array.prototype.slice.call(arguments, 2);
 
   var state = sibilant.state,
-      $1 = map([ k, v ], (function() {
+      $4 = map([ k, v ], (function() {
     /* src/macros/misc.sibilant:71:41 */
   
     return outputFormatter(transpile(arguments[0]));
   })),
-      key = $1[0],
-      value = $1[1],
-      $1 = undefined,
+      key = $4[0],
+      value = $4[1],
+      $4 = undefined,
       before = state[key];
   state[key] = value;
   var returnValue = interleave("\n", map(body, transpile));
@@ -7440,16 +7440,16 @@ transpile.hat = (function transpile$hat$(node) {
   /* transpile.hat src/transpiler.sibilant:55:0 */
 
   var token = node.contents[0].token,
-      if$1 = (function() {
+      if$2 = (function() {
     if (token.match((new RegExp("\/", undefined)))) {
       return token.split("/");
     } else {
       return [ sibilant.macros.searchPath[0], token ];
     }
   }).call(this),
-      namespace = if$1[0],
-      macro = if$1[1],
-      if$1 = undefined;
+      namespace = if$2[0],
+      macro = if$2[1],
+      if$2 = undefined;
   return sibilant.macros.namespaces.core.get.call(node, "sibilant.macros.namespaces", sibilant.macros.namespaces.core.quote(transpile.literal({ token: namespace })), sibilant.macros.namespaces.core.quote(transpile.literal({ token: macro })));
 });
 transpile.tick = (function transpile$tick$(node) {

--- a/lib/sibilant.js
+++ b/lib/sibilant.js
@@ -37,7 +37,9 @@ var relativeDirAndFile = sibilant.relativeDirAndFile;
 sibilant.recordDependency = (function sibilant$recordDependency$(from, to) {
   /* sibilant.record-dependency src/node.sibilant:17:0 */
 
-  sibilant.dependencies[from] = (typeof sibilant.dependencies[from] !== "undefined") ? sibilant.dependencies[from] : [];
+  sibilant.dependencies[from] = (function() {
+    return (typeof sibilant.dependencies[from] !== "undefined") ? sibilant.dependencies[from] : [];
+  }).call(this);
   return sibilant.dependencies[from].push(to);
 });
 sibilant.flatDependencies = (function sibilant$flatDependencies$() {
@@ -54,7 +56,9 @@ sibilant.entry = (function sibilant$entry$(source, options) {
       return source = undefined;
     }
   }).call(this);
-  options = (typeof options !== "undefined") ? options : {  };
+  options = (function() {
+    return (typeof options !== "undefined") ? options : {  };
+  }).call(this);
   (function() {
     if (typeof source === "string") {
       return options.source = source;
@@ -65,8 +69,12 @@ sibilant.entry = (function sibilant$entry$(source, options) {
       file = options.file,
       quoteKeys = options.quoteKeys,
       json = options.json;
-  map = (typeof map !== "undefined") ? map : false;
-  quoteKeys = (typeof quoteKeys !== "undefined") ? quoteKeys : json;
+  map = (function() {
+    return (typeof map !== "undefined") ? map : false;
+  }).call(this);
+  quoteKeys = (function() {
+    return (typeof quoteKeys !== "undefined") ? quoteKeys : json;
+  }).call(this);
   (function() {
     if (((typeof file !== "undefined" && file !== null) && !((typeof source !== "undefined" && source !== null)))) {
       var relativeDirAndF$4 = relativeDirAndFile(file),
@@ -357,8 +365,12 @@ var white = (function white$(args) {
 sibilant.prettyPrint = (function sibilant$prettyPrint$(node, color, entry) {
   /* sibilant.pretty-print src/pretty-printer.sibilant:3:0 */
 
-  entry = (typeof entry !== "undefined") ? entry : true;
-  color = (typeof color !== "undefined") ? color : true;
+  entry = (function() {
+    return (typeof entry !== "undefined") ? entry : true;
+  }).call(this);
+  color = (function() {
+    return (typeof color !== "undefined") ? color : true;
+  }).call(this);
   return realNewlines((function() {
     if (node__QUERY(node)) {
       var prettyPrinter = (sibilant.prettyPrint[node.type] || sibilant.prettyPrint.default);
@@ -811,13 +823,15 @@ var orderedRegexes = parser.orderedRegexes;
 parser.parse = (function parser$parse$(string, context) {
   /* parser.parse src/parser.sibilant:48:0 */
 
-  context = (typeof context !== "undefined") ? context : {
-    position: 0,
-    stack: [],
-    line: 1,
-    lastNewline: 0,
-    col: 0
-  };
+  context = (function() {
+    return (typeof context !== "undefined") ? context : {
+      position: 0,
+      stack: [],
+      line: 1,
+      lastNewline: 0,
+      col: 0
+    };
+  }).call(this);
   var match = true,
       regexName = null,
       remainingInput = string;
@@ -1345,10 +1359,10 @@ sibilant.macros.namespaces.core["="] = (function $$(args) {
 sibilant.macros.namespaces.core.ternary = (function ternary$(cond, ifTrue, ifFalse) {
   /* ternary src/macros/flow-control.sibilant:9:0 */
 
-  return [ "(", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse) ];
+  return [ "(function() {", indent([ "return (", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse), ";" ]), "}).call(this)" ];
 });
 sibilant.macros.namespaces.core.when = (function when$(condition, body) {
-  /* when src/macros/flow-control.sibilant:21:0 */
+  /* when src/macros/flow-control.sibilant:26:0 */
 
   var body = Array.prototype.slice.call(arguments, 1);
 
@@ -1356,13 +1370,13 @@ sibilant.macros.namespaces.core.when = (function when$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 24,
+    line: 29,
     col: 18,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "do",
       type: "literal",
-      line: 24,
+      line: 29,
       col: 19,
       contents: [],
       specials: 0,
@@ -1376,7 +1390,7 @@ sibilant.macros.namespaces.core.when = (function when$(condition, body) {
   }), "}");
 });
 sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
-  /* unless src/macros/flow-control.sibilant:33:0 */
+  /* unless src/macros/flow-control.sibilant:38:0 */
 
   var body = Array.prototype.slice.call(arguments, 1);
 
@@ -1384,13 +1398,13 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 35,
+    line: 40,
     col: 25,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "not",
       type: "literal",
-      line: 35,
+      line: 40,
       col: 26,
       contents: [],
       specials: 0,
@@ -1405,13 +1419,13 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 36,
+    line: 41,
     col: 33,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "do",
       type: "literal",
-      line: 36,
+      line: 41,
       col: 34,
       contents: [],
       specials: 0,
@@ -1425,12 +1439,12 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
   }), "}" ]), "}).call(this)" ];
 });
 sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranches) {
-  /* if src/macros/flow-control.sibilant:58:0 */
+  /* if src/macros/flow-control.sibilant:63:0 */
 
   var alternatingConditionsAndBranches = Array.prototype.slice.call(arguments, 0);
 
   return [ "(function() {", indent(interleave(" else ", bulkMap(alternatingConditionsAndBranches, (function(cond, val) {
-    /* src/macros/flow-control.sibilant:63:25 */
+    /* src/macros/flow-control.sibilant:68:25 */
   
     return (function() {
       if (typeof val !== "undefined") {
@@ -1438,13 +1452,13 @@ sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranc
           file: "src/macros/flow-control.sibilant",
           token: "(",
           type: "expression",
-          line: 66,
+          line: 71,
           col: 44,
           contents: [ {
             file: "src/macros/flow-control.sibilant",
             token: "do",
             type: "literal",
-            line: 66,
+            line: 71,
             col: 45,
             contents: [],
             specials: 0,
@@ -1461,13 +1475,13 @@ sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranc
           file: "src/macros/flow-control.sibilant",
           token: "(",
           type: "expression",
-          line: 68,
+          line: 73,
           col: 47,
           contents: [ {
             file: "src/macros/flow-control.sibilant",
             token: "do",
             type: "literal",
-            line: 68,
+            line: 73,
             col: 48,
             contents: [],
             specials: 0,
@@ -4134,7 +4148,9 @@ sibilant.macros.namespaces.core.comment = (function comment$(contents) {
     return [ "// ", recurseMap(transpile(content), (function(item) {
       /* src/macros/misc.sibilant:29:36 */
     
-      return (item) ? outputFormatter(transpile(item)).replace((new RegExp("\n", "g")), "\n// ") : null;
+      return (function() {
+        return (item) ? outputFormatter(transpile(item)).replace((new RegExp("\n", "g")), "\n// ") : null;
+      }).call(this);
     })) ];
   }));
 });
@@ -7108,8 +7124,12 @@ var generateSymbol = (function generateSymbol$(clue) {
   /* generate-symbol src/helpers.sibilant:171:0 */
 
   var state = sibilant.state;
-  clue = (typeof clue !== "undefined") ? clue : "temp";
-  state.symbolCounts = (typeof state.symbolCounts !== "undefined") ? state.symbolCounts : {  };
+  clue = (function() {
+    return (typeof clue !== "undefined") ? clue : "temp";
+  }).call(this);
+  state.symbolCounts = (function() {
+    return (typeof state.symbolCounts !== "undefined") ? state.symbolCounts : {  };
+  }).call(this);
   var count = ((state.symbolCounts[clue] || 0) + 1);
   state.symbolCounts[clue] = count;
   return [ ("" + clue + "$" + count) ];

--- a/src/cli.sibilant
+++ b/src/cli.sibilant
@@ -109,10 +109,10 @@
            (var output-path (concat (path.join output-dir input-basename)
                                     output-extname))
 
-           (fs.write-file output-path result.js)
+           (fs.write-file-sync output-path result.js)
            (when map-dir
                  (var map-path (concat (path.join map-dir input-basename) ".map"))
-                 (fs.write-file map-path (result.map.to-string))))
+                 (fs.write-file-sync map-path (result.map.to-string))))
           
        cli-options.execute
        (run-in-sandbox result.js input-path)

--- a/src/macros/flow-control.sibilant
+++ b/src/macros/flow-control.sibilant
@@ -7,10 +7,15 @@
          "fifty is more than 100"))
 
 (macro ternary (cond if-true if-false)
-       ["(" (transpile cond) ") ? "
-            (transpile if-true) " : "
-            (transpile if-false)])
-
+       ["(function() {"
+        (indent ["return ("
+                 (transpile cond)
+                 ") ? "
+                 (transpile if-true)
+                 " : "
+                 (transpile if-false)
+                 ";"])
+        "}).call(this)"])
 
 (docs "evaluates statements in `body` if `condition` is true. `body`
       is `scoped` in a self-evaluating function to support having a

--- a/src/repl.sibilant
+++ b/src/repl.sibilant
@@ -75,7 +75,7 @@ fs.access(HISTORY-FILE fs.R-OK
 
        (var result (vm.run-in-context safe-js context "sibilant-repl"))
        (set readline.history 0 cmd-buffer)
-       fs.write(fd (""cmd-buffer"\n\n"))
+       fs.write-sync(fd (""cmd-buffer"\n\n"))
        (when (defined? result)
              (output.write ("result: "
                             (util.inspect result { colors true }) "\n")))
@@ -88,7 +88,7 @@ fs.access(HISTORY-FILE fs.R-OK
             (readline.history.shift))
            (do
             (set readline.history 0 cmd-buffer)
-            fs.write(fd (""cmd-buffer"\n\n"))
+            fs.write-sync(fd (""cmd-buffer"\n\n"))
             (output.write (concat e.stack "\n"))
             (assign  cmd-buffer "")))))
      (display-prompt))

--- a/test/test.sibilant
+++ b/test/test.sibilant
@@ -144,6 +144,18 @@
   }
 }).call(this)")
 
+; ternary
+
+(assert-translation "(ternary a b c)"
+"(function() {
+  return (a) ? b : c;
+}).call(this)")
+
+(assert-translation "(\"prefix-\" (ternary true \"b\" \"c\") \"-suffix\")"
+"(\"prefix-\" + (function() {
+  return (true) ? \"b\" : \"c\";
+}).call(this) + \"-suffix\")")
+
 ; do
 
 (assert-translation "(do a b c d e)"
@@ -710,8 +722,12 @@ b();"))
 })"))
 
 (assert-translation "(default foo 1 bar 2)"
-                    "foo = (typeof foo !== \"undefined\") ? foo : 1;
-bar = (typeof bar !== \"undefined\") ? bar : 2;")
+                    "foo = (function() {
+  return (typeof foo !== \"undefined\") ? foo : 1;
+}).call(this);
+bar = (function() {
+  return (typeof bar !== \"undefined\") ? bar : 2;
+}).call(this);")
 
 
 (assert-translation "(pipe a (b c) (d e) (+ 1) (.to-string) (.to-upper-case))"


### PR DESCRIPTION
Compiling using the cli with `sibilant src/*.sibilant -o lib` was
failing because the callback parameter to writeFile is no longer
optional as of Node v10.0.0